### PR TITLE
Remove homepage reference to "sunburst" fill style

### DIFF
--- a/index.md
+++ b/index.md
@@ -77,7 +77,7 @@ rc.rectangle(120, 105, 80, 80, {
 });
 ```
 
-Fill styles can be: **hachure**(default), **solid**, **zigzag**, **cross-hatch**, **dots**, **sunburst**, **dashed**, or **zigzag-line**
+Fill styles can be: **hachure**(default), **solid**, **zigzag**, **cross-hatch**, **dots**, **dashed**, or **zigzag-line**
 
 ![Rough.js fill examples](/images/m14.png)
 


### PR DESCRIPTION
Sunburst fill is no longer supported in 4.0 release but is still listed as an option on the roughjs.com homepage.